### PR TITLE
Fix service template syntax

### DIFF
--- a/templates/service.template.ts
+++ b/templates/service.template.ts
@@ -30,11 +30,6 @@ export class <%= entityName %>Service {
     const entity = await this.dataSourceService
       .getDataSource()
       .getRepository(<%= entityName %>Entity)
-  async findByExternalId(external_id: string): Promise<{{entityName}}QueryDTO> {
-    this.logger.log(`Finding {{entityLower}} with External ID: ${external_id}`);
-    const entity = await this.dataSourceService
-      .getDataSource()
-      .getRepository({{entityName}}Entity)
       .findOne({
         where: { external_id }
       });


### PR DESCRIPTION
## Summary
- clean up `templates/service.template.ts`
- drop stray Mustache syntax and finish the `findByExternalId` method

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6866773689c0832f8285dce159d0353e