### PR TITLE
Fix create-issues on manual workflow runs

### DIFF
--- a/.github/workflows/create-issues.yml
+++ b/.github/workflows/create-issues.yml
@@ -26,7 +26,12 @@ jobs:
           set -e
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          files=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" -- '.github/ISSUE/*.md')
+          BEFORE="${{ github.event.before }}"
+          if [ -z "$BEFORE" ]; then
+            files=$(git ls-files '.github/ISSUE/*.md')
+          else
+            files=$(git diff --name-only "$BEFORE" "${{ github.sha }}" -- '.github/ISSUE/*.md')
+          fi
           for file in $files; do
             echo "Processing $file"
             title=$(grep '^name:' "$file" | head -n1 | sed 's/^name:[[:space:]]*//' | tr -d '"')


### PR DESCRIPTION
## Summary
- improve workflow to handle empty `github.event.before`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6866ebd5f22c832f906feba333269606