### PR TITLE
Fix workflow to use proper setup-gh action

### DIFF
--- a/.github/workflows/create-issues.yml
+++ b/.github/workflows/create-issues.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up GitHub CLI
-        uses: actions/setup-gh@v4
+        uses: actions/setup-gh-cli@v2
       - name: Create issues and PRs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to use `actions/setup-gh-cli` instead of nonexistent `actions/setup-gh`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68671854ff90832f8f7b7a84db3a9d34