### PR TITLE
Fix AWK variable name in create-issues workflow

### DIFF
--- a/.github/workflows/create-issues.yml
+++ b/.github/workflows/create-issues.yml
@@ -40,7 +40,7 @@ jobs:
             sanitized=$(echo "$title" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd '[:alnum:]-')
             labels=$(grep '^labels:' "$file" | head -n1 | sed 's/^labels:[[:space:]]*//' | tr -d '"')
             assignees=$(grep '^assignees:' "$file" | head -n1 | sed 's/^assignees:[[:space:]]*//' | tr -d "'")
-            body=$(awk 'BEGIN{in=0} /^---$/{in++; next} in>=2 {print}' "$file")
+            body=$(awk 'BEGIN{section=0} /^---$/{section++; next} section>=2 {print}' "$file")
             issue_url=$(gh issue create --title "$title" --body "$body" ${labels:+--label "$labels"} ${assignees:+--assignee "$assignees"})
             issue_number=$(basename "$issue_url")
             branch="issue-$issue_number-$sanitized"


### PR DESCRIPTION
## Summary
- fix AWK variable name in `.github/workflows/create-issues.yml`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68671f588b04832fa3fa25f85b75d9cd