### PR TITLE
Fix workflow action reference

### DIFF
--- a/.github/workflows/create-issues.yml
+++ b/.github/workflows/create-issues.yml
@@ -17,8 +17,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up GitHub CLI
-        uses: actions/setup-gh@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: '20.x'
       - name: Create issues and PRs


### PR DESCRIPTION
## Summary
- fix workflow to use `actions/setup-node@v4`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68671a398900832f97b9e985511fcd73