### PR TITLE
Fix uuid generation on existing templates

### DIFF
--- a/.github/workflows/create-issues.yml
+++ b/.github/workflows/create-issues.yml
@@ -42,11 +42,15 @@ jobs:
           changed=false
           for file in $files; do
             [ -f "$file" ] || continue
-            if grep -q '^uuid:' "$file"; then
+            if grep -Eq '^uuid:[[:space:]]*[0-9a-fA-F-]{36}$' "$file"; then
               continue
             fi
             uuid=$(command -v uuidgen >/dev/null && uuidgen || node -e "console.log(require('crypto').randomUUID())")
-            sed -i "/^assignees:/a uuid: $uuid" "$file"
+            if grep -q '^uuid:' "$file"; then
+              sed -i "s/^uuid:.*$/uuid: $uuid/" "$file"
+            else
+              sed -i "/^assignees:/a uuid: $uuid" "$file"
+            fi
             git add "$file"
             changed=true
           done


### PR DESCRIPTION
## Summary
- ensure uuid step checks for a full 36-character value
- overwrite empty `uuid:` lines instead of skipping

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686740df74f8832f8aa08fb030922aac