### PR TITLE
Change Dependabot update interval from weekly to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This pull request introduces a new `.github/dependabot.yml` configuration file to the repository. This sets up the foundation for automated dependency updates using Dependabot, although the specific package ecosystem is not yet specified.

Dependency management setup:

* Added a `.github/dependabot.yml` file with initial configuration for Dependabot, specifying a monthly update schedule but leaving the `package-ecosystem` value to be filled in later.