### PR TITLE
Add GitHub Actions to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,8 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "monthly"
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "monthly"
+      commit-message:
+          prefix: "ci"


### PR DESCRIPTION
This pull request updates the Dependabot configuration to enable and customize automated updates for GitHub Actions workflows. The configuration now specifies the package ecosystem, update schedule, and commit message prefix for these updates.

Dependabot configuration updates:

* Enabled Dependabot updates for the `github-actions` package ecosystem, targeting the root directory (`/`).
* Set the update schedule to run monthly for GitHub Actions dependencies.
* Added a custom commit message prefix (`ci`) for Dependabot pull requests related to GitHub Actions.Updated Dependabot configuration to include GitHub Actions.