### PR TITLE
docs: setup do ambiente de desenvolvimento (Cursor Cloud)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1795,3 +1795,19 @@ opencode.json
 ---
 
 **Remember**: This repository's primary purpose is **workflow solutions testing**, not ensuring specific projects work perfectly. The fixtures are **mocks for testing workflow genericity**.
+
+---
+
+## Cursor Cloud specific instructions
+
+Contexto durável e não óbvio para agentes na VM do Cursor Cloud (dependências já instaladas pelo update script). Comandos padrão continuam documentados no `README.md` e no `Makefile`; aqui ficam apenas caveats.
+
+- **Produto central:** o gerador `node-gen` em `gen/` (CLI). O update script instala as dependências da raiz e de `gen/`; `gen/` precisa de `--legacy-peer-deps` porque não herda o `.npmrc` da raiz (npm não sobe diretórios). Antes de usar o CLI, compile com `npm run build` na raiz (gera `gen/dist/`). Build NÃO faz parte do update script.
+- **Docker ausente:** a VM não possui Docker. Os fluxos que dependem de Docker não rodam aqui: stack completa SSPA/APIs (`make projects-up`), testes Playwright (`make playwright-test`, `npm run test:playwright`) e E2E multi-banco (`make e2e*`, que sobem Postgres/MySQL/SQL Server). Use o caminho SQLite para validação local.
+- **`npm run test:e2e` não é sinal confiável aqui:** o harness `test/e2e-generator/e2e.js` verifica estrutura antiga (`src/app/...`) enquanto o gerador atual emite `output/<app>/api/src/modules/...`, e ainda exige containers de banco acessíveis. Para SQLite ele pula o start da API (`e2eSkipApiStartForDbTypes: ["sqlite"]`), fazendo apenas geração + build.
+- **Componentes do CLI usam prefixo `api-*`** (`api-entities,api-services,api-interfaces,api-controllers,api-dtos,api-modules,api-app-module,api-main,api-datasource,api-readme`). Os nomes antigos do `README.md` (`entities`, `services`, ...) são impressos como "não reconhecido". Componentes válidos estão no `switch` de `gen/src/main.ts`.
+- **Criar mock SQLite:** `NODE_PATH=gen/node_modules E2E_DB_TYPES=sqlite node test/e2e-generator/run.js db <projeto>` gera `test/e2e-generator/mock.sqlite` (projeto `todo`) ou `mock-<projeto>.sqlite`. Esses `.sqlite` não são versionados.
+- **Rodar uma API gerada contra SQLite (sem Docker):** dentro de `output/<app>/api/` rode `npm install --legacy-peer-deps` e adicione o driver `sqlite3` (`npm install sqlite3 --legacy-peer-deps`) — o `package.json` gerado só traz `pg`. Suba com `NODE_ENV=production E2E_SKIP_JWT=true DATABASE_TYPE=sqlite DATABASE_PATH=<abs .sqlite> PORT=<p> MICROSERVICE_TCP_PORT=<único> node dist/main.js` (após `npm run build`). `NODE_ENV=production` desativa Swagger e o health-check de sessão JWT; `E2E_SKIP_JWT=true` libera as rotas.
+- **Porta do microserviço TCP:** o `main.ts` gerado sobe um microserviço TCP em `MICROSERVICE_TCP_PORT` (default 3000). Ao rodar várias APIs, defina uma porta única por instância para evitar `EADDRINUSE`.
+- **Defeitos conhecidos do código gerado no path SQLite** (não são problemas de ambiente; não "corrigir" fora de escopo): colunas anuláveis viram `NOT NULL`; defaults de string ficam super-escapados (`DEFAULT (''active'')`, quebra o `synchronize`); relações geram `*_eid` no service divergindo de `*_id` no DTO (quebra o build). Para demonstração de runtime, prefira fixtures de tabela única sem default de string (`contacts`, `tenant`, `users`) e envie todos os campos no POST.
+- **Sem lint no gerador:** não há script de lint nem `eslint.config` para `gen/`/raiz (ESLint só existe em `sspa-static/*` e nos apps gerados). "Lint" do produto central não se aplica.

--- a/CHANGELOG/20260718211427.md
+++ b/CHANGELOG/20260718211427.md
@@ -1,0 +1,32 @@
+<!-- CHANGELOG/20260718211427.md -->
+# 2026-07-18 21:14:27 UTC — Configuração do ambiente de desenvolvimento (Cursor Cloud)
+
+## Escopo
+Configuração e validação do ambiente de desenvolvimento na VM do Cursor Cloud, sem alteração de código-fonte do produto. Apenas documentação (`AGENTS.md` + este changelog) e definição do update script de startup.
+
+## Arquivos alterados
+- `AGENTS.md` — nova seção `## Cursor Cloud specific instructions` com caveats duráveis (Docker ausente, build do gerador, componentes `api-*`, execução da API gerada contra SQLite, defeitos conhecidos do path SQLite, ausência de lint no gerador).
+- `CHANGELOG/20260718211427.md` — esta entrada.
+
+## Comandos executados
+- `npm install` (raiz) — 351 pacotes.
+- `npm install --prefix gen --legacy-peer-deps` — deps do gerador, incluindo módulos nativos `sqlite3` e `sharp`.
+- `npm run build` — compila `gen/` para `gen/dist/` (tsc), sucesso.
+- `NODE_PATH=gen/node_modules E2E_DB_TYPES=sqlite node test/e2e-generator/run.js db contacts` — cria mock SQLite.
+- `node gen/dist/main.js -a hello-contacts -d test/e2e-generator/mock-contacts.sqlite -t sqlite -f "api-*"` — gera API NestJS.
+- `npm install --legacy-peer-deps` + `npm install sqlite3 --legacy-peer-deps` + `npm run build` na API gerada — build OK.
+- Execução da API gerada e verificação via `curl`: `/health` (200), `/version` (200) e CRUD `POST /contact` (201) + `GET /contact` (200).
+
+## Resultado
+- PASSOU: build do gerador, geração de API, build da API gerada, execução e ação CRUD end-to-end contra SQLite.
+- NÃO EXECUTADO (motivo objetivo): stack SSPA/Playwright/E2E multi-banco — Docker indisponível na VM.
+
+## Update script de startup (Cursor Cloud)
+```
+npm install
+npm install --prefix gen --legacy-peer-deps
+```
+
+## Pendências / observações
+- Defeitos de geração no path SQLite (colunas anuláveis como `NOT NULL`, defaults de string super-escapados, relação `*_eid` vs `*_id`) permanecem no código gerado; fora do escopo desta configuração de ambiente.
+- O harness `test/e2e-generator/e2e.js` espera estrutura antiga (`src/app/...`) divergente da saída atual (`api/src/modules/...`); não alterado.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objetivo
Configurar e validar o ambiente de desenvolvimento na VM do Cursor Cloud, sem alterar código-fonte do produto. Apenas documentação e definição do update script de startup.

## Arquivos alterados
- `AGENTS.md` — nova seção `## Cursor Cloud specific instructions` (caveats duráveis).
- `CHANGELOG/20260718211427.md` — entrada de rastreabilidade da configuração.

## Comandos executados
- `npm install` (raiz)
- `npm install --prefix gen --legacy-peer-deps` (deps do gerador; `gen/` não herda o `.npmrc` da raiz)
- `npm run build` (compila o gerador `gen/` → `gen/dist/`)
- Geração de API NestJS a partir de mock SQLite (`node gen/dist/main.js ... -t sqlite -f api-*`)
- Build + execução da API gerada e verificação via `curl`

## Update script (startup)
```
npm install
npm install --prefix gen --legacy-peer-deps
```
Papel: refresh mínimo e idempotente de dependências. Build (`npm run build`) e execução de serviços ficam fora do update script e documentados no `AGENTS.md`.

## Resultado (passou/falhou)
- PASSOU: build do gerador; geração de API NestJS; build da API gerada; execução e ação CRUD end-to-end contra SQLite.
  - `GET /health` → 200 `{"status":"ok","info":{"database":{"status":"up"}}}`
  - `GET /version` → 200
  - `POST /contact` → 201 (cria registro) e `GET /contact` → 200 (lista com o registro)
- NÃO EXECUTADO (motivo objetivo): stack completa SSPA/APIs, Playwright e E2E multi-banco — **Docker indisponível** na VM do Cloud.

## Observações
- Defeitos conhecidos no código gerado no path SQLite (colunas anuláveis viram `NOT NULL`; defaults de string super-escapados; relação `*_eid` vs `*_id`) estão documentados no `AGENTS.md`; são bugs do produto, fora do escopo desta configuração de ambiente (nenhum código-fonte foi alterado).
- Sem lint/tests unitários configurados para o gerador; `npm run test:e2e` depende de Docker e de estrutura antiga, portanto não é sinal confiável nesta VM.

## Evidência
[Evidência de ambiente funcional (build, geração, /health, CRUD)](https://cursor.com/artifacts/c/art-d8fee8bb-09b2-4d31-8204-4b14de721f67)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3482da99-554d-47be-9619-8e97c6ae0a4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3482da99-554d-47be-9619-8e97c6ae0a4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

